### PR TITLE
feat: load experiences from supabase

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,10 +1,32 @@
 import { motion } from "framer-motion";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { experiences } from "@/data/portfolio";
 import { MapPin, Calendar, Users, Code } from "lucide-react";
+import { useExperiences } from "@/hooks/use-experiences";
 
 const Experience = () => {
+  const experiences = useExperiences();
+
+  if (!experiences) {
+    return (
+      <section id="experience" className="py-24">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <p>Loading...</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (experiences.length === 0) {
+    return (
+      <section id="experience" className="py-24">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <p>No experiences found.</p>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section id="experience" className="py-24">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -1,15 +1,3 @@
-export interface Experience {
-  id: string;
-  company: string;
-  role: string;
-  type: 'IC' | 'Lead';
-  duration: string;
-  location: string;
-  description: string;
-  achievements: string[];
-  skills: string[];
-}
-
 export interface Project {
   id: string;
   title: string;
@@ -33,57 +21,6 @@ export interface Skill {
   category: 'Backend' | 'Data' | 'Cloud' | 'Platform/Infra' | 'DX' | 'Leadership';
   level: 'Beginner' | 'Intermediate' | 'Advanced' | 'Expert';
 }
-
-export const experiences: Experience[] = [
-  {
-    id: "1",
-    company: "TechCorp Inc",
-    role: "Senior Software Engineer & Tech Lead",
-    type: "Lead",
-    duration: "2022 - Present",
-    location: "San Francisco, CA",
-    description: "Leading a team of 5 engineers while maintaining hands-on technical contributions to high-scale distributed systems.",
-    achievements: [
-      "Reduced P99 latency by 40% through database optimization and caching strategies",
-      "Led migration to microservices architecture, improving system reliability by 99.9%",
-      "Mentored 3 junior engineers, with 2 receiving promotions within 12 months",
-      "Cut infrastructure costs by 30% through containerization and auto-scaling implementation"
-    ],
-    skills: ["Java", "Spring Boot", "Kubernetes", "PostgreSQL", "Redis", "Team Leadership"]
-  },
-  {
-    id: "2",
-    company: "StartupXYZ",
-    role: "Software Engineer",
-    type: "IC",
-    duration: "2020 - 2022",
-    location: "Austin, TX",
-    description: "Full-stack development focused on building scalable web applications and APIs.",
-    achievements: [
-      "Built real-time analytics dashboard handling 1M+ daily events",
-      "Increased API throughput by 60% through async processing and connection pooling",
-      "Implemented CI/CD pipeline reducing deployment time from 2 hours to 15 minutes",
-      "Decreased bug reports by 45% through comprehensive testing strategy"
-    ],
-    skills: ["Node.js", "React", "TypeScript", "MongoDB", "AWS", "Docker"]
-  },
-  {
-    id: "3",
-    company: "DevSolutions Ltd",
-    role: "Junior Software Developer",
-    type: "IC",
-    duration: "2019 - 2020",
-    location: "Remote",
-    description: "Frontend and backend development with focus on learning modern development practices.",
-    achievements: [
-      "Delivered 15+ features for e-commerce platform serving 10k+ users",
-      "Improved page load times by 35% through code optimization and lazy loading",
-      "Contributed to open-source projects with 500+ GitHub stars",
-      "Achieved 95% test coverage across all modules"
-    ],
-    skills: ["JavaScript", "Vue.js", "Python", "Flask", "MySQL", "Git"]
-  }
-];
 
 export const projects: Project[] = [
   {

--- a/src/hooks/use-experiences.ts
+++ b/src/hooks/use-experiences.ts
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
+
+export interface Experience {
+  id: string;
+  company: string;
+  role: string;
+  type: Database["public"]["Enums"]["role_type"];
+  duration: string;
+  location: string | null;
+  description: string;
+  achievements: string[];
+  skills: string[];
+}
+
+type ExperienceRow = Database["public"]["Tables"]["experiences"]["Row"];
+
+function formatDuration(start: string, end: string | null) {
+  const startStr = format(new Date(start), "MMM yyyy");
+  const endStr = end ? format(new Date(end), "MMM yyyy") : "Present";
+  return `${startStr} - ${endStr}`;
+}
+
+function mapExperience(row: ExperienceRow): Experience {
+  return {
+    id: row.id,
+    company: row.company,
+    role: row.title,
+    type: row.role,
+    duration: formatDuration(row.start_date, row.end_date),
+    location: row.location,
+    description: row.summary ?? "",
+    achievements: row.highlights ?? [],
+    skills: row.tags ?? [],
+  };
+}
+
+export function useExperiences() {
+  const { data } = useQuery<Experience[]>({
+    queryKey: ["experiences"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("experiences")
+        .select(
+          "id, company, title, role, summary, highlights, tags, start_date, end_date, location"
+        )
+        .eq("is_published", true)
+        .order("sort_order", { ascending: false })
+        .order("start_date", { ascending: false });
+
+      if (error) throw error;
+      return data?.map(mapExperience) ?? [];
+    },
+  });
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- fetch experiences from Supabase and compute durations
- wire Experience component to use hook with loading and empty states
- remove static experiences data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a03d6b8968832b8f32c7d0f952459a