### PR TITLE
Use env vars for Supabase configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for Vite Supabase integration
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ This project is built with:
 - React
 - shadcn-ui
 - Tailwind CSS
+ 
+## Environment Variables
+
+Copy `.env.example` to `.env` and provide values for the following variables:
+
+```
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+```
+
+Variables prefixed with `VITE_` are exposed to the client by Vite and can be accessed in the code via `import.meta.env`.
 
 ## How can I deploy this project?
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,13 +2,13 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://envwvmjtxlcelqgbhjdu.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVudnd2bWp0eGxjZWxxZ2JoamR1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUzMjY2NDIsImV4cCI6MjA3MDkwMjY0Mn0.m4xE4Uz5u6bS_i_lqobFMrKbqBYjyRfYJbc_DK0psH8";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
     storage: localStorage,
     persistSession: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,5 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  envPrefix: "VITE_",
 }));


### PR DESCRIPTION
## Summary
- load Supabase URL and anon key from Vite environment variables
- expose VITE_* variables via Vite config
- document required Supabase env vars and provide `.env.example`

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, A require() style import is forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a040455f4c832b8bdfceb0e847d380