### PR TITLE
refactor: centralize social link constants

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -6,16 +6,17 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { 
-  Mail, 
-  Phone, 
-  MapPin, 
-  Github, 
-  Linkedin, 
+import {
+  Mail,
+  Phone,
+  MapPin,
+  Github,
+  Linkedin,
   Calendar,
   Send,
   CheckCircle2
 } from "lucide-react";
+import { SOCIAL_LINKS } from "@/data/socials";
 
 const Contact = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -58,9 +59,9 @@ const Contact = () => {
   const contactInfo = [
     {
       icon: Mail,
-      label: "Email",
-      value: "alex.chen@example.com",
-      href: "mailto:alex.chen@example.com"
+      label: SOCIAL_LINKS.email.label,
+      value: SOCIAL_LINKS.email.address,
+      href: SOCIAL_LINKS.email.url
     },
     {
       icon: Phone,
@@ -79,21 +80,21 @@ const Contact = () => {
   const socialLinks = [
     {
       icon: Github,
-      label: "GitHub",
-      href: "https://github.com/alexchen",
-      username: "@alexchen"
+      label: SOCIAL_LINKS.github.label,
+      href: SOCIAL_LINKS.github.url,
+      username: SOCIAL_LINKS.github.username
     },
     {
       icon: Linkedin,
-      label: "LinkedIn",
-      href: "https://linkedin.com/in/alexchen",
-      username: "in/alexchen"
+      label: SOCIAL_LINKS.linkedin.label,
+      href: SOCIAL_LINKS.linkedin.url,
+      username: SOCIAL_LINKS.linkedin.username
     },
     {
       icon: Calendar,
-      label: "Schedule a Call",
-      href: "https://calendly.com/alexchen",
-      username: "Book 30min call"
+      label: SOCIAL_LINKS.calendly.label,
+      href: SOCIAL_LINKS.calendly.url,
+      username: SOCIAL_LINKS.calendly.username
     }
   ];
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,14 +1,15 @@
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Github, Linkedin, Mail, ArrowUp } from "lucide-react";
+import { SOCIAL_LINKS } from "@/data/socials";
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();
 
   const socialLinks = [
-    { icon: Github, href: "https://github.com/alexchen", label: "GitHub" },
-    { icon: Linkedin, href: "https://linkedin.com/in/alexchen", label: "LinkedIn" },
-    { icon: Mail, href: "mailto:alex.chen@example.com", label: "Email" },
+    { icon: Github, href: SOCIAL_LINKS.github.url, label: SOCIAL_LINKS.github.label },
+    { icon: Linkedin, href: SOCIAL_LINKS.linkedin.url, label: SOCIAL_LINKS.linkedin.label },
+    { icon: Mail, href: SOCIAL_LINKS.email.url, label: SOCIAL_LINKS.email.label },
   ];
 
   const scrollToTop = () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { useTheme } from "next-themes";
 import { Moon, Sun, Menu, X, Github, Linkedin, Mail } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
+import { SOCIAL_LINKS } from "@/data/socials";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -17,9 +18,9 @@ const Header = () => {
   ];
 
   const socialLinks = [
-    { name: "GitHub", icon: Github, href: "#" },
-    { name: "LinkedIn", icon: Linkedin, href: "#" },
-    { name: "Email", icon: Mail, href: "mailto:contact@example.com" },
+    { name: SOCIAL_LINKS.github.label, icon: Github, href: SOCIAL_LINKS.github.url },
+    { name: SOCIAL_LINKS.linkedin.label, icon: Linkedin, href: SOCIAL_LINKS.linkedin.url },
+    { name: SOCIAL_LINKS.email.label, icon: Mail, href: SOCIAL_LINKS.email.url },
   ];
 
   return (

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
 import { Download, ArrowRight, Github, Linkedin, Mail } from "lucide-react";
 import heroImage from "@/assets/hero-image.jpg";
+import { SOCIAL_LINKS } from "@/data/socials";
 
 const Hero = () => {
   return (
@@ -101,9 +102,9 @@ const Hero = () => {
               <span className="text-sm text-muted-foreground font-medium">Connect with me:</span>
               <div className="flex gap-2">
                 {[
-                  { icon: Github, href: "https://github.com/alexchen", label: "GitHub" },
-                  { icon: Linkedin, href: "https://linkedin.com/in/alexchen", label: "LinkedIn" },
-                  { icon: Mail, href: "mailto:alex@example.com", label: "Email" }
+                  { icon: Github, href: SOCIAL_LINKS.github.url, label: SOCIAL_LINKS.github.label },
+                  { icon: Linkedin, href: SOCIAL_LINKS.linkedin.url, label: SOCIAL_LINKS.linkedin.label },
+                  { icon: Mail, href: SOCIAL_LINKS.email.url, label: SOCIAL_LINKS.email.label }
                 ].map(({ icon: Icon, href, label }) => (
                   <Button
                     key={label}

--- a/src/data/socials.ts
+++ b/src/data/socials.ts
@@ -1,0 +1,28 @@
+export const SOCIAL_LINKS = {
+  github: {
+    label: "GitHub",
+    url: "https://github.com/alexchen",
+    username: "@alexchen"
+  },
+  linkedin: {
+    label: "LinkedIn",
+    url: "https://linkedin.com/in/alexchen",
+    username: "in/alexchen"
+  },
+  email: {
+    label: "Email",
+    address: "alex.chen@example.com",
+    url: "mailto:alex.chen@example.com"
+  },
+  calendly: {
+    label: "Schedule a Call",
+    url: "https://calendly.com/alexchen",
+    username: "Book 30min call"
+  }
+} as const;
+
+export const EMAIL_ADDRESS = SOCIAL_LINKS.email.address;
+export const EMAIL_URL = SOCIAL_LINKS.email.url;
+export const GITHUB_URL = SOCIAL_LINKS.github.url;
+export const LINKEDIN_URL = SOCIAL_LINKS.linkedin.url;
+export const CALENDLY_URL = SOCIAL_LINKS.calendly.url;


### PR DESCRIPTION
## Summary
- centralize GitHub, LinkedIn, email, and Calendly links in `SOCIAL_LINKS`
- update Hero, Footer, Contact, and Header components to use shared constants

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a04cfba834832b90033e4c3af29ebf