### PR TITLE
test: cover supabase fetch fallbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "bun test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/src/hooks/use-experiences.test.ts
+++ b/src/hooks/use-experiences.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "bun:test";
+import { createMockClient } from "../test-utils";
+import type { Experience } from "./use-experiences";
+import type { Database } from "@/integrations/supabase/types";
+
+const localStorageMock = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+};
+(globalThis as unknown as { localStorage: typeof localStorage }).localStorage =
+  localStorageMock as unknown as typeof localStorage;
+
+const { fetchExperiences } = await import("./use-experiences");
+
+const sampleRow: Partial<Database["public"]["Tables"]["experiences"]["Row"]> = {
+  id: "1",
+  company: "Acme",
+  title: "Engineer",
+  role: "IC",
+  summary: "Did things",
+  highlights: ["Shipped"],
+  tags: ["React"],
+  start_date: "2020-01-01",
+  end_date: null,
+  location: "Remote",
+  sort_order: 1,
+  is_published: true,
+};
+
+describe("fetchExperiences", () => {
+  it("returns mapped experiences when supabase responds", async () => {
+    const client = createMockClient({ data: [sampleRow], error: null }, 2);
+    const result = await fetchExperiences(client);
+    expect(result).toEqual<Experience[]>([
+      {
+        id: "1",
+        company: "Acme",
+        role: "Engineer",
+        type: "IC",
+        duration: "Jan 2020 - Present",
+        location: "Remote",
+        description: "Did things",
+        achievements: ["Shipped"],
+        skills: ["React"],
+      },
+    ]);
+  });
+
+  it("returns empty array when supabase fails", async () => {
+    const client = createMockClient({ data: null, error: new Error("down") }, 2);
+    const result = await fetchExperiences(client);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/hooks/use-experiences.ts
+++ b/src/hooks/use-experiences.ts
@@ -37,22 +37,27 @@ function mapExperience(row: ExperienceRow): Experience {
   };
 }
 
+export async function fetchExperiences(client = supabase): Promise<Experience[]> {
+  const { data, error } = await client
+    .from("experiences")
+    .select(
+      "id, company, title, role, summary, highlights, tags, start_date, end_date, location"
+    )
+    .eq("is_published", true)
+    .order("sort_order", { ascending: false })
+    .order("start_date", { ascending: false });
+
+  if (error) {
+    console.error(error);
+    return [];
+  }
+  return data?.map(mapExperience) ?? [];
+}
+
 export function useExperiences() {
   const { data } = useQuery<Experience[]>({
     queryKey: ["experiences"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("experiences")
-        .select(
-          "id, company, title, role, summary, highlights, tags, start_date, end_date, location"
-        )
-        .eq("is_published", true)
-        .order("sort_order", { ascending: false })
-        .order("start_date", { ascending: false });
-
-      if (error) throw error;
-      return data?.map(mapExperience) ?? [];
-    },
+    queryFn: () => fetchExperiences(),
   });
 
   return data;

--- a/src/hooks/use-projects.test.ts
+++ b/src/hooks/use-projects.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "bun:test";
+import { createMockClient } from "../test-utils";
+import type { Project } from "./use-projects";
+import type { Database } from "@/integrations/supabase/types";
+
+const localStorageMock = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+};
+(globalThis as unknown as { localStorage: typeof localStorage }).localStorage =
+  localStorageMock as unknown as typeof localStorage;
+
+const { fetchProjects } = await import("./use-projects");
+
+const sampleRow: Partial<Database["public"]["Tables"]["projects"]["Row"]> = {
+  id: "1",
+  title: "Test Project",
+  subtitle: "A project",
+  problem: "Problem",
+  approach: "Approach",
+  outcome: "Outcome",
+  tech_stack: ["React"],
+  links: { github: "https://github.com" } as unknown as Database["public"]["Tables"]["projects"]["Row"]["links"],
+  is_lead: true,
+  sort_order: 1,
+  is_published: true,
+};
+
+describe("fetchProjects", () => {
+  it("returns mapped projects when supabase responds", async () => {
+    const client = createMockClient({ data: [sampleRow], error: null });
+    const result = await fetchProjects(client);
+    expect(result).toEqual<Project[]>([
+      {
+        id: "1",
+        title: "Test Project",
+        description: "A project",
+        problem: "Problem",
+        approach: "Approach",
+        outcome: "Outcome",
+        techStack: ["React"],
+        links: { github: "https://github.com" },
+        featured: true,
+        leadership: true,
+      },
+    ]);
+  });
+
+  it("returns empty array when supabase fails", async () => {
+    const client = createMockClient({ data: null, error: new Error("down") });
+    const result = await fetchProjects(client);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -41,21 +41,26 @@ function mapProject(row: ProjectRow, index: number): Project {
   };
 }
 
+export async function fetchProjects(client = supabase): Promise<Project[]> {
+  const { data, error } = await client
+    .from("projects")
+    .select(
+      "id, title, subtitle, problem, approach, outcome, tech_stack, links, is_lead, sort_order"
+    )
+    .eq("is_published", true)
+    .order("sort_order", { ascending: false });
+
+  if (error) {
+    console.error(error);
+    return [];
+  }
+  return (data ?? []).map(mapProject);
+}
+
 export function useProjects() {
   const { data } = useQuery<Project[]>({
     queryKey: ["projects"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("projects")
-        .select(
-          "id, title, subtitle, problem, approach, outcome, tech_stack, links, is_lead, sort_order"
-        )
-        .eq("is_published", true)
-        .order("sort_order", { ascending: false });
-
-      if (error) throw error;
-      return (data ?? []).map(mapProject);
-    },
+    queryFn: () => fetchProjects(),
   });
 
   return data;

--- a/src/hooks/use-skills.test.ts
+++ b/src/hooks/use-skills.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import { createMockClient } from "../test-utils";
+import { Server } from "lucide-react";
+import type { SkillCategory } from "./use-skills";
+import type { Database } from "@/integrations/supabase/types";
+
+const localStorageMock = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+};
+(globalThis as unknown as { localStorage: typeof localStorage }).localStorage =
+  localStorageMock as unknown as typeof localStorage;
+
+const { fetchSkills } = await import("./use-skills");
+
+const sampleRow: Partial<
+  Database["public"]["Tables"]["skill_categories"]["Row"] & {
+    skill_category_skills: Array<
+      Database["public"]["Tables"]["skill_category_skills"]["Row"] & {
+        skills: Database["public"]["Tables"]["skills"]["Row"];
+      }
+    >;
+  }
+> = {
+  slug: "backend",
+  name: "Backend",
+  sort_order: 1,
+  is_published: true,
+  skill_category_skills: [
+    {
+      sort_order: 1,
+      skills: { name: "Node", level: "Expert" } as Database["public"]["Tables"]["skills"]["Row"],
+    },
+  ],
+};
+
+describe("fetchSkills", () => {
+  it("returns mapped skills when supabase responds", async () => {
+    const client = createMockClient({ data: [sampleRow], error: null }, 2);
+    const result = await fetchSkills(client);
+    expect(result).toEqual<SkillCategory[]>([
+      {
+        name: "Backend",
+        icon: Server,
+        skills: [{ name: "Node", level: "Expert" }],
+      },
+    ]);
+  });
+
+  it("returns empty array when supabase fails", async () => {
+    const client = createMockClient({ data: null, error: new Error("down") }, 2);
+    const result = await fetchSkills(client);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "bun:test";
+import { cn } from "./utils";
+
+describe("cn", () => {
+  it("merges class names", () => {
+    expect(cn("p-2", "text-sm", "p-2")).toBe("text-sm p-2");
+  });
+});

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,23 @@
+export function createMockClient<T>({ data, error }: { data: T | null; error: Error | null }, orders = 1) {
+  return {
+    from() {
+      let orderCalls = 0;
+      const query = {
+        select() {
+          return query;
+        },
+        eq() {
+          return query;
+        },
+        order() {
+          orderCalls++;
+          if (orderCalls >= orders) {
+            return Promise.resolve({ data, error });
+          }
+          return query;
+        },
+      };
+      return query;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- handle Supabase errors gracefully in project, skill, and experience fetchers
- add unit tests verifying data mapping and empty-array fallbacks

## Testing
- `npm test`
- `npm run lint` *(fails: textarea interface and tailwind config issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a04db0da80832ba025c0a8350ba9b9