### PR TITLE
feat: enable email contact form

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
 # Environment variables for Vite Supabase integration
 VITE_SUPABASE_URL=https://envwvmjtxlcelqgbhjdu.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVudnd2bWp0eGxjZWxxZ2JoamR1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUzMjY2NDIsImV4cCI6MjA3MDkwMjY0Mn0.m4xE4Uz5u6bS_i_lqobFMrKbqBYjyRfYJbc_DK0psH8
+
+# Formspree form ID for contact submissions
+VITE_FORMSPREE_FORM_ID=your-formspree-id

--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@ A developer portfolio built with [React](https://react.dev/), [Vite](https://vit
 - Responsive landing page with sections for hero, about, experience, projects, skills and contact.
 - Data-driven content powered by Supabase.
 - Animated UI components built with shadcn/ui and framer-motion.
+- Contact form powered by [Formspree](https://formspree.io/) for email notifications.
 
 ## Getting Started
 1. **Install dependencies**
    ```sh
    npm install
    ```
-2. **Configure environment** – create a `.env` file with your Supabase project credentials:
+2. **Configure environment** – create a `.env` file with your Supabase project credentials and Formspree form ID:
    ```dotenv
    VITE_SUPABASE_URL=your-url
    VITE_SUPABASE_ANON_KEY=your-anon-key
+   VITE_FORMSPREE_FORM_ID=your-formspree-id
    ```
 3. **Run the app**
    ```sh

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -34,26 +34,48 @@ const Contact = () => {
     setFormData(prev => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsSubmitting(true);
 
-    // Simulate form submission
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    setIsSubmitting(false);
-    setIsSubmitted(true);
-    
-    toast({
-      title: "Message sent successfully!",
-      description: "I'll get back to you within 24 hours.",
-    });
+    try {
+      const response = await fetch(
+        `https://formspree.io/f/${import.meta.env.VITE_FORMSPREE_FORM_ID}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify(formData),
+        }
+      );
 
-    // Reset form after 3 seconds
-    setTimeout(() => {
-      setIsSubmitted(false);
-      setFormData({ name: "", email: "", message: "" });
-    }, 3000);
+      if (!response.ok) {
+        throw new Error("Form submission failed");
+      }
+
+      setIsSubmitted(true);
+      toast({
+        title: "Message sent successfully!",
+        description: "I'll get back to you within 24 hours.",
+      });
+
+      // Reset form after 3 seconds
+      setTimeout(() => {
+        setIsSubmitted(false);
+        setFormData({ name: "", email: "", message: "" });
+      }, 3000);
+    } catch (error) {
+      console.error("Error submitting contact form", error);
+      toast({
+        title: "Something went wrong",
+        description: "Please try again later.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const contactInfo = [


### PR DESCRIPTION
## Summary
- send contact form submissions to Formspree endpoint for email alerts
- document Formspree configuration in README and env file

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a059dc0328832b932e86e86758642c