### PR TITLE
feat: add blog section with categories

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "@/components/theme-provider";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Blog from "./pages/Blog";
 
 const queryClient = new QueryClient();
 
@@ -21,11 +22,12 @@ const App = () => (
         <Toaster />
         <Sonner />
         <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Index />} />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+            <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="/blog" element={<Blog />} />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
         </BrowserRouter>
       </TooltipProvider>
     </ThemeProvider>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,13 +9,14 @@ const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { theme, setTheme } = useTheme();
 
-  const navItems = [
-    { name: "About", href: "#about" },
-    { name: "Experience", href: "#experience" },
-    { name: "Projects", href: "#projects" },
-    { name: "Skills", href: "#skills" },
-    { name: "Contact", href: "#contact" },
-  ];
+    const navItems = [
+      { name: "Blog", href: "/blog" },
+      { name: "About", href: "/#about" },
+      { name: "Experience", href: "/#experience" },
+      { name: "Projects", href: "/#projects" },
+      { name: "Skills", href: "/#skills" },
+      { name: "Contact", href: "/#contact" },
+    ];
 
   const socialLinks = [
     { name: SOCIAL_LINKS.github.label, icon: Github, href: SOCIAL_LINKS.github.url },

--- a/src/hooks/use-blog-posts.test.ts
+++ b/src/hooks/use-blog-posts.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "bun:test";
+import { createMockClient } from "../test-utils";
+import type { Database } from "@/integrations/supabase/types";
+import type { BlogPost } from "./use-blog-posts";
+
+const localStorageMock = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+};
+(globalThis as unknown as { localStorage: typeof localStorage }).localStorage =
+  localStorageMock as unknown as typeof localStorage;
+
+const { fetchBlogPosts } = await import("./use-blog-posts");
+
+const sampleCategory: Database["public"]["Tables"]["blog_categories"]["Row"] = {
+  id: "1",
+  slug: "ranting",
+  name: "Ranting",
+  sort_order: 1,
+  is_published: true,
+  created_at: "2020-01-01",
+  updated_at: "2020-01-01",
+};
+
+const sampleRow: Partial<Database["public"]["Tables"]["blog_posts"]["Row"]> & {
+  blog_categories: Database["public"]["Tables"]["blog_categories"]["Row"];
+} = {
+  id: "1",
+  category_id: "1",
+  title: "Post",
+  content: "Content",
+  created_at: "2020-01-01",
+  blog_categories: sampleCategory,
+};
+
+describe("fetchBlogPosts", () => {
+  it("returns mapped posts when supabase responds", async () => {
+    const client = createMockClient({ data: [sampleRow], error: null });
+    const result = await fetchBlogPosts(client);
+    expect(result).toEqual<BlogPost[]>([
+      {
+        id: "1",
+        title: "Post",
+        content: "Content",
+        createdAt: "2020-01-01",
+        category: { slug: "ranting", name: "Ranting" },
+      },
+    ]);
+  });
+
+  it("returns empty array when supabase fails", async () => {
+    const client = createMockClient({ data: null, error: new Error("down") });
+    const result = await fetchBlogPosts(client);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/hooks/use-blog-posts.ts
+++ b/src/hooks/use-blog-posts.ts
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
+
+export interface BlogPost {
+  id: string;
+  title: string;
+  content: string | null;
+  createdAt: string;
+  category: {
+    slug: string;
+    name: string;
+  };
+}
+
+type BlogPostRow = Database["public"]["Tables"]["blog_posts"]["Row"] & {
+  blog_categories: Database["public"]["Tables"]["blog_categories"]["Row"];
+};
+
+function mapPost(row: BlogPostRow): BlogPost {
+  return {
+    id: row.id,
+    title: row.title,
+    content: row.content ?? null,
+    createdAt: row.created_at,
+    category: {
+      slug: row.blog_categories.slug,
+      name: row.blog_categories.name,
+    },
+  };
+}
+
+export async function fetchBlogPosts(client = supabase): Promise<BlogPost[]> {
+  const { data, error } = await client
+    .from("blog_posts")
+    .select("id, title, content, created_at, blog_categories(slug, name)")
+    .eq("is_published", true)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error(error);
+    return [];
+  }
+
+  return (
+    data?.map((row) =>
+      mapPost(row as BlogPostRow)
+    ) ?? []
+  );
+}
+
+export function useBlogPosts() {
+  const { data } = useQuery<BlogPost[]>({
+    queryKey: ["blog_posts"],
+    queryFn: () => fetchBlogPosts(),
+  });
+
+  return data;
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -131,6 +131,74 @@ export type Database = {
         }
         Relationships: []
       }
+      blog_categories: {
+        Row: {
+          id: string
+          slug: string
+          name: string
+          sort_order: number | null
+          is_published: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          slug: string
+          name: string
+          sort_order?: number | null
+          is_published?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          slug?: string
+          name?: string
+          sort_order?: number | null
+          is_published?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      blog_posts: {
+        Row: {
+          id: string
+          category_id: string
+          title: string
+          content: string | null
+          is_published: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          category_id: string
+          title: string
+          content?: string | null
+          is_published?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          category_id?: string
+          title?: string
+          content?: string | null
+          is_published?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "blog_posts_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "blog_categories"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       skill_categories: {
         Row: {
           created_at: string

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,0 +1,37 @@
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import { useBlogPosts } from "@/hooks/use-blog-posts";
+
+const Blog = () => {
+  const posts = useBlogPosts() ?? [];
+  const categories = Array.from(
+    new Map(posts.map((p) => [p.category.slug, p.category.name])).entries()
+  ).map(([slug, name]) => ({ slug, name }));
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <main className="container py-10 space-y-10">
+        {categories.length === 0 && <p>No posts yet.</p>}
+        {categories.map((cat) => (
+          <section key={cat.slug} className="space-y-4">
+            <h2 className="text-2xl font-bold">{cat.name}</h2>
+            {posts
+              .filter((p) => p.category.slug === cat.slug)
+              .map((post) => (
+                <article key={post.id} className="p-4 border rounded-lg space-y-2">
+                  <h3 className="text-xl font-semibold">{post.title}</h3>
+                  {post.content && (
+                    <p className="text-sm text-muted-foreground">{post.content}</p>
+                  )}
+                </article>
+              ))}
+          </section>
+        ))}
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Blog;

--- a/supabase/migrations/20250816084500_add_blog_tables.sql
+++ b/supabase/migrations/20250816084500_add_blog_tables.sql
@@ -1,0 +1,61 @@
+-- Add blog categories and posts tables
+
+-- Blog categories table
+create table if not exists public.blog_categories (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  name text not null,
+  sort_order int default 0,
+  is_published boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists blog_categories_sort_idx on public.blog_categories (is_published desc, sort_order desc, name);
+
+drop trigger if exists set_blog_categories_updated_at on public.blog_categories;
+create trigger set_blog_categories_updated_at
+before update on public.blog_categories
+for each row execute function public.set_updated_at();
+
+-- Blog posts table
+create table if not exists public.blog_posts (
+  id uuid primary key default gen_random_uuid(),
+  category_id uuid not null references public.blog_categories(id) on delete cascade,
+  title text not null,
+  content text,
+  is_published boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists blog_posts_sort_idx on public.blog_posts (is_published desc, created_at desc);
+
+drop trigger if exists set_blog_posts_updated_at on public.blog_posts;
+create trigger set_blog_posts_updated_at
+before update on public.blog_posts
+for each row execute function public.set_updated_at();
+
+-- Enable RLS and public read access
+alter table public.blog_categories enable row level security;
+alter table public.blog_posts enable row level security;
+
+create policy if not exists "Public read blog_categories" on public.blog_categories for select using (true);
+create policy if not exists "Public read blog_posts" on public.blog_posts for select using (true);
+
+-- Realtime support
+alter table public.blog_categories replica identity full;
+alter table public.blog_posts replica identity full;
+
+do $$
+begin
+  if exists (select 1 from pg_publication where pubname = 'supabase_realtime') then
+    execute 'alter publication supabase_realtime add table public.blog_categories, public.blog_posts';
+  end if;
+end$$;
+
+-- Update helper function listing content tables
+create or replace function public.get_content_tables()
+returns text[] language sql stable security definer set search_path = public as $$
+  select array['experiences','skill_categories','skills','skill_category_skills','projects','blog_categories','blog_posts']
+$$;

--- a/supabase/migrations/20250816084600_seed_blog.sql
+++ b/supabase/migrations/20250816084600_seed_blog.sql
@@ -1,0 +1,11 @@
+-- Seed blog categories and example posts
+
+insert into public.blog_categories (slug, name, sort_order) values
+  ('ranting', 'Ranting', 1),
+  ('knowledge', 'Knowledge', 2),
+  ('trials-and-failures', 'Trials and Failures', 3);
+
+insert into public.blog_posts (category_id, title, content) values
+  ((select id from public.blog_categories where slug = 'ranting'), 'Welcome to My Rants', 'This is my first rant.'),
+  ((select id from public.blog_categories where slug = 'knowledge'), 'Sharing Some Knowledge', 'An article sharing knowledge.'),
+  ((select id from public.blog_categories where slug = 'trials-and-failures'), 'Trials and Failures', 'A story about trials and failures.');


### PR DESCRIPTION
## Summary
- create Supabase tables for blog categories and posts
- add blog page and navigation to display posts by category
- implement hook and types for fetching posts

## Testing
- `npm test`
- `npm run lint` *(fails: `textarea.tsx` no-empty-object-type, `tailwind.config.ts` no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a05a082de8832b9d45b2fdbf200992