### PR TITLE
ci: configure pages with action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,16 +23,9 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - name: Enable GitHub Pages
-        run: |
-          curl -L -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ github.token }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/pages \
-            -d '{"build_type":"workflow"}' \
-            || true
       - uses: actions/configure-pages@v5
+        with:
+          enablement: enable
       - run: npm ci
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- use `actions/configure-pages@v5` to enable GitHub Pages automatically

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08d0205e8832ba05cdc917d4574a2