### PR TITLE
chore: use Node 20 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
       - uses: actions/configure-pages@v5
         with:


### PR DESCRIPTION
## Summary
- use Node.js 20 for GitHub Pages deployment workflow

## Testing
- `npm test`
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0923d6430832b923268a92fe846c8