### PR TITLE
Set BrowserRouter base path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter>
+        <BrowserRouter basename="/sys-craft-folio">
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/blog" element={<Blog />} />


### PR DESCRIPTION
## Summary
- configure BrowserRouter with `/sys-craft-folio` base path to support routing when served from subdirectory

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0923b981c832bb95bc26936059c5d