### PR TITLE
fix: ensure NotFound home link respects base path

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -16,7 +16,10 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <a
+          href={import.meta.env.BASE_URL}
+          className="text-blue-500 hover:text-blue-700 underline"
+        >
           Return to Home
         </a>
       </div>


### PR DESCRIPTION
## Summary
- use `import.meta.env.BASE_URL` for NotFound page home link

## Testing
- `npm run lint`
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon npm test`
- `npm run build:dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0953e9464832bbdcdc92a14ae4e4a