### PR TITLE
chore: set PUBLIC_URL and configure supabase test env

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=http://localhost:54321
+VITE_SUPABASE_ANON_KEY=public-anon-key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,8 @@ jobs:
           enablement: enable
       - run: npm ci
       - run: npm run build
+        env:
+          PUBLIC_URL: /sys-craft-folio/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "prepare": "git config core.hooksPath .githooks",
-    "test": "bun test"
+    "test": "bun test --env-file .env.test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const SUPABASE_URL = (import.meta.env.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL) as string;
+const SUPABASE_ANON_KEY = (import.meta.env.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY) as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- ensure GitHub Pages uses correct asset paths by setting PUBLIC_URL during build
- load Supabase configuration from `.env.test` and allow client to read env vars to avoid missing supabaseUrl

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a09a339c9c832b97bb6ce38688f28e